### PR TITLE
Remove php@7.1-tideways-xhprof rename

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -1,6 +1,5 @@
 {
   "php-tideways": "php-tideways-xhprof",
   "php@7.3-tideways": "php@7.3-tideways-xhprof",
-  "php@7.2-tideways": "php@7.2-tideways-xhprof",
-  "php@7.1-tideways": "php@7.1-tideways-xhprof"
+  "php@7.2-tideways": "php@7.2-tideways-xhprof"
 }


### PR DESCRIPTION
7.1 formulas were removed in https://github.com/kabel/homebrew-pecl/commit/a20f2e3ac09410b923e0321c94a31d717e8f7d71