### PR TITLE
Add xhprof 2.2.0

### DIFF
--- a/Aliases/php@7.4-xhprof
+++ b/Aliases/php@7.4-xhprof
@@ -1,0 +1,1 @@
+../Formula/php-xhprof.rb

--- a/Formula/php-xhprof.rb
+++ b/Formula/php-xhprof.rb
@@ -1,0 +1,8 @@
+require_relative "../lib/php_pecl_formula"
+
+class PhpXhprof < PhpPeclFormula
+  extension_dsl "XHProf: A Hierarchical Profiler for PHP"
+
+  url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
+  sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+end

--- a/Formula/php-xhprof.rb
+++ b/Formula/php-xhprof.rb
@@ -5,4 +5,8 @@ class PhpXhprof < PhpPeclFormula
 
   url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
   sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+
+  def source_dir
+    "#{extension}-#{version}/extension"
+  end
 end

--- a/Formula/php-xhprof.rb
+++ b/Formula/php-xhprof.rb
@@ -5,6 +5,7 @@ class PhpXhprof < PhpPeclFormula
 
   url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
   sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+  license "Apache-2.0"
 
   def source_dir
     "#{extension}-#{version}/extension"

--- a/Formula/php@7.2-xhprof.rb
+++ b/Formula/php@7.2-xhprof.rb
@@ -5,6 +5,7 @@ class PhpAT72Xhprof < PhpPeclFormula
 
   url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
   sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+  license "Apache-2.0"
 
   def source_dir
     "#{extension}-#{version}/extension"

--- a/Formula/php@7.2-xhprof.rb
+++ b/Formula/php@7.2-xhprof.rb
@@ -5,4 +5,8 @@ class PhpAT72Xhprof < PhpPeclFormula
 
   url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
   sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+
+  def source_dir
+    "#{extension}-#{version}/extension"
+  end
 end

--- a/Formula/php@7.2-xhprof.rb
+++ b/Formula/php@7.2-xhprof.rb
@@ -1,0 +1,8 @@
+require_relative "../lib/php_pecl_formula"
+
+class PhpAT72Xhprof < PhpPeclFormula
+  extension_dsl "XHProf: A Hierarchical Profiler for PHP"
+
+  url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
+  sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+end

--- a/Formula/php@7.3-xhprof.rb
+++ b/Formula/php@7.3-xhprof.rb
@@ -1,0 +1,8 @@
+require_relative "../lib/php_pecl_formula"
+
+class PhpAT73Xhprof < PhpPeclFormula
+  extension_dsl "XHProf: A Hierarchical Profiler for PHP"
+
+  url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
+  sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+end

--- a/Formula/php@7.3-xhprof.rb
+++ b/Formula/php@7.3-xhprof.rb
@@ -5,4 +5,8 @@ class PhpAT73Xhprof < PhpPeclFormula
 
   url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
   sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+
+  def source_dir
+    "#{extension}-#{version}/extension"
+  end
 end

--- a/Formula/php@7.3-xhprof.rb
+++ b/Formula/php@7.3-xhprof.rb
@@ -5,6 +5,7 @@ class PhpAT73Xhprof < PhpPeclFormula
 
   url "https://pecl.php.net/get/xhprof-2.2.0.tgz"
   sha256 "034b3141411f3aaf44f91a0ec86a5f4c805a9372c4ef4f9c5ba38ef0b56f4fa2"
+  license "Apache-2.0"
 
   def source_dir
     "#{extension}-#{version}/extension"


### PR DESCRIPTION
xhgui got rebooted, and supports php 7 now:
- https://pecl.php.net/package/xhprof
- homepage: https://github.com/longxinH/xhprof

Can be used by https://github.com/perftools/php-profiler