### PR TITLE
Fix Xdebug Alias and Xdebug for PHP 7.4

### DIFF
--- a/Aliases/php@8.0-xdebug
+++ b/Aliases/php@8.0-xdebug
@@ -1,0 +1,1 @@
+../Formula/php-xdebug.rb

--- a/Formula/php@7.4-xdebug.rb
+++ b/Formula/php@7.4-xdebug.rb
@@ -1,6 +1,6 @@
 require_relative "../lib/php_pecl_formula"
 
-class PhpAT72Xdebug < PhpPeclFormula
+class PhpAT74Xdebug < PhpPeclFormula
   extension_dsl "An extension to assist with debugging and development"
 
   url "https://pecl.php.net/get/xdebug-3.0.0.tgz"


### PR DESCRIPTION
The migration for Xdebug was incomplete.