### PR TITLE
php-imagick: revision for upstream dependency update

### DIFF
--- a/Formula/php@7.3-imagick.rb
+++ b/Formula/php@7.3-imagick.rb
@@ -6,7 +6,7 @@ class PhpAT73Imagick < PhpPeclFormula
   url "https://pecl.php.net/get/imagick-3.4.4.tgz"
   sha256 "8dd5aa16465c218651fc8993e1faecd982e6a597870fd4b937e9ece02d567077"
   license "PHP-3.01"
-  revision 2
+  revision 3
 
   bottle do
     root_url "https://kabel.jfrog.io/artifactory/bottles-pecl"

--- a/Formula/php@7.4-imagick.rb
+++ b/Formula/php@7.4-imagick.rb
@@ -6,7 +6,7 @@ class PhpAT74Imagick < PhpPeclFormula
   url "https://pecl.php.net/get/imagick-3.4.4.tgz"
   sha256 "8dd5aa16465c218651fc8993e1faecd982e6a597870fd4b937e9ece02d567077"
   license "PHP-3.01"
-  revision 3
+  revision 4
 
   bottle do
     root_url "https://kabel.jfrog.io/artifactory/bottles-pecl"


### PR DESCRIPTION
Related to e780af651ae24287cd4d2d0c2bfe76b67d2f37d0

This fixed the following warning for me:
```
php --version
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so' (tried: /usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so (dlopen(/usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so, 9): image not found), /usr/local/lib/php/pecl/20190902//usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so.so (dlopen(/usr/local/lib/php/pecl/20190902//usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so.so, 9): image not found)) in Unknown on line 0

Warning: PHP Startup: Unable to load dynamic library '/usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so' (tried: /usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so (dlopen(/usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so, 9): image not found), /usr/local/lib/php/pecl/20190902//usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so.so (dlopen(/usr/local/lib/php/pecl/20190902//usr/local/opt/php@7.4-imagick/lib/php/20190902/imagick.so.so, 9): image not found)) in Unknown on line 0
PHP 7.4.15 (cli) (built: Feb  4 2021 12:11:40) ( NTS )
Copyright (c) The PHP Group
Zend Engine v3.4.0, Copyright (c) Zend Technologies
    with Zend OPcache v7.4.15, Copyright (c), by Zend Technologies
    with Xdebug v3.0.2, Copyright (c) 2002-2021, by Derick Rethans
```

My ImageMagick version:
```
➜  20190902 cd /usr/local/opt/imagemagick/lib/            
➜  lib ls -l
total 18240
drwxr-xr-x   4 user  staff      128  7 Feb 22:45 ImageMagick
-rw-r--r--   1 user  staff   585560 12 Feb 11:30 libMagick++-7.Q16HDRI.5.dylib
-r--r--r--   1 user  staff   912976  7 Feb 22:45 libMagick++-7.Q16HDRI.a
lrwxr-xr-x   1 user  staff       29  7 Feb 22:45 libMagick++-7.Q16HDRI.dylib -> libMagick++-7.Q16HDRI.5.dylib
-rwxr-xr-x   1 user  staff     1447 12 Feb 11:30 libMagick++-7.Q16HDRI.la
-r--r--r--   1 user  staff  1997984 12 Feb 11:30 libMagickCore-7.Q16HDRI.9.dylib
-r--r--r--   1 user  staff  2988664  7 Feb 22:45 libMagickCore-7.Q16HDRI.a
lrwxr-xr-x   1 user  staff       31  7 Feb 22:45 libMagickCore-7.Q16HDRI.dylib -> libMagickCore-7.Q16HDRI.9.dylib
-rwxr-xr-x   1 user  staff     1317 12 Feb 11:30 libMagickCore-7.Q16HDRI.la
-r--r--r--   1 user  staff  1169168 12 Feb 11:30 libMagickWand-7.Q16HDRI.9.dylib
-r--r--r--   1 user  staff  1665488  7 Feb 22:45 libMagickWand-7.Q16HDRI.a
lrwxr-xr-x   1 user  staff       31  7 Feb 22:45 libMagickWand-7.Q16HDRI.dylib -> libMagickWand-7.Q16HDRI.9.dylib
-rwxr-xr-x   1 user  staff     1388 12 Feb 11:30 libMagickWand-7.Q16HDRI.la
drwxr-xr-x  10 user  staff      320 12 Feb 11:30 pkgconfig
```

I'm not sure if this breaks other setups or if the revision has to also be updated for other PHP versions.