### PR TITLE
Fix “already initialized constant” warning for NAME_PATTERN in PhpPeclFormula

### DIFF
--- a/lib/php_pecl_formula.rb
+++ b/lib/php_pecl_formula.rb
@@ -66,7 +66,9 @@ class PhpPeclFormula < Formula
   end
 
   class << self
-    NAME_PATTERN = /^Php(?:AT([578])(\d+))?(.+)/
+    unless const_defined?(:NAME_PATTERN)
+      NAME_PATTERN = /^Php(?:AT([578])(\d+))?(.+)/
+    end
     attr_reader :configure_args, :php_parent, :extension
 
     attr_rw :source_dir, :conf_order


### PR DESCRIPTION
Starting with Homebrew 4.4.22, previously cleaned-up constants are no longer removed between loads, causing warnings such as:

```
/opt/homebrew/Library/Taps/kabel/homebrew-pecl/lib/php_pecl_formula.rb:69: warning: previous definition of NAME_PATTERN was here
/opt/homebrew/Library/Taps/kabel/homebrew-pecl/lib/php_pecl_formula.rb:69: warning: already initialized constant Class::NAME_PATTERN
```

This pull request fixes the issue by ensuring NAME_PATTERN is only defined once, thereby eliminating the repeated initialization warnings.